### PR TITLE
Standardize on pyenv for all ubuntu images, add 22.04 image

### DIFF
--- a/.github/workflows/build-aptly.yml
+++ b/.github/workflows/build-aptly.yml
@@ -19,51 +19,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Docker Context for Buildx
-        id: buildx-context
-        run: |
-          docker context create builders
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
-          endpoint: builders
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PAT }}
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            chianetwork/aptly
-          tags: |
-            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-            type=sha,format=long
-
-      - name: Build Docker Container
-        uses: docker/build-push-action@v4
-        with:
-          context: ./aptly
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+    uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
+    with:
+      docker-context: "./aptly"
+      dockerfile: "./aptly/Dockerfile"
+      dockerhub_imagename: "chianetwork/aptly"
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}

--- a/.github/workflows/build-centos7.yml
+++ b/.github/workflows/build-centos7.yml
@@ -17,34 +17,15 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
   cancel-in-progress: true
 
+
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PAT }}
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            chianetwork/centos7-builder
-          tags: |
-            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-            type=sha,format=long
-
-      - name: Build Docker Container
-        uses: docker/build-push-action@v4
-        with:
-          context: ./centos7
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+    uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
+    with:
+      docker-context: "./centos7"
+      dockerfile: "./centos7/Dockerfile"
+      dockerhub_imagename: "chianetwork/centos7-builder"
+      docker-platforms: linux/amd64
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}

--- a/.github/workflows/build-manylinux2014-cuda.yml
+++ b/.github/workflows/build-manylinux2014-cuda.yml
@@ -22,6 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         arch: [aarch64, x86_64]
 

--- a/.github/workflows/build-ubuntu-18.04.yml
+++ b/.github/workflows/build-ubuntu-18.04.yml
@@ -19,51 +19,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Docker Context for Buildx
-        id: buildx-context
-        run: |
-          docker context create builders
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
-          endpoint: builders
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PAT }}
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            chianetwork/ubuntu-18.04-builder
-          tags: |
-            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-            type=sha,format=long
-
-      - name: Build Docker Container
-        uses: docker/build-push-action@v4
-        with:
-          context: ./ubuntu-18.04
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+    uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
+    with:
+      docker-context: "./ubuntu-18.04"
+      dockerfile: "./ubuntu-18.04/Dockerfile"
+      dockerhub_imagename: "chianetwork/ubuntu-18.04-builder"
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}

--- a/.github/workflows/build-ubuntu-20.04.yml
+++ b/.github/workflows/build-ubuntu-20.04.yml
@@ -19,51 +19,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Docker Context for Buildx
-        id: buildx-context
-        run: |
-          docker context create builders
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          version: latest
-          endpoint: builders
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PAT }}
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            chianetwork/ubuntu-20.04-builder
-          tags: |
-            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-            type=sha,format=long
-
-      - name: Build Docker Container
-        uses: docker/build-push-action@v4
-        with:
-          context: ./ubuntu-20.04
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+    uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
+    with:
+      docker-context: "./ubuntu-20.04"
+      dockerfile: "./ubuntu-20.04/Dockerfile"
+      dockerhub_imagename: "chianetwork/ubuntu-20.04-builder"
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}

--- a/.github/workflows/build-ubuntu-22.04.yml
+++ b/.github/workflows/build-ubuntu-22.04.yml
@@ -1,0 +1,28 @@
+name: Build Ubuntu 22.04 Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'ubuntu-22.04/*'
+      - '.github/workflows/build-ubuntu-22.04.yml'
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 12 * * 5'
+
+concurrency:
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
+    with:
+      docker-context: "./ubuntu-22.04"
+      dockerhub_imagename: "chianetwork/ubuntu-22.04-builder"
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}

--- a/.github/workflows/build-ubuntu-22.04.yml
+++ b/.github/workflows/build-ubuntu-22.04.yml
@@ -22,6 +22,7 @@ jobs:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
       docker-context: "./ubuntu-22.04"
+      dockerfile: "./ubuntu-22.04/Dockerfile"
       dockerhub_imagename: "chianetwork/ubuntu-22.04-builder"
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV PYENV_ROOT=/root/.pyenv
 ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
@@ -6,7 +6,9 @@ ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
         apt-utils \
-        software-properties-common  && \
+        gpg \
+        gpg-agent \
+        software-properties-common && \
     add-apt-repository ppa:git-core/ppa -y && \
     add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends \
@@ -15,8 +17,8 @@ RUN apt-get update && \
         curl \
         dialog \
         fakeroot \
-        g++-9 \
-        g++-10 \
+        g++-12 \
+        g++-13 \
         git \
         jq \
         libbz2-dev \
@@ -36,8 +38,8 @@ RUN apt-get update && \
         zlib1g-dev && \
     # Set up pyenv \
     git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    pyenv install 3.9 && \
-    pyenv global 3.9 && \
+    pyenv install 3.10 && \
+    pyenv global 3.10 && \
     pip install --upgrade pip && \
     pip install --no-cache-dir py3createtorrent && \
     rm -rf /var/lib/apt/lists/*
@@ -49,7 +51,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
 
 # Newer version of CMAKE
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
-    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null && \
     apt-get update && \
     apt-get install cmake -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- [x] Still needs 22.04 workflow
- [x] Ideally, the docker workflow is using the shared upstream, but that needs optional dockerhub support