### PR TITLE
Run on k8s runner w/ higher timeout

### DIFF
--- a/.github/workflows/build-ubuntu-22.04-risc.yml
+++ b/.github/workflows/build-ubuntu-22.04-risc.yml
@@ -21,6 +21,8 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      runs-on: k8s-public
+      timeout-minutes: 1440
       docker-context: "./ubuntu-22.04-risc"
       dockerfile: "./ubuntu-22.04-risc/Dockerfile"
       dockerhub_imagename: "chianetwork/ubuntu-22.04-risc-builder"


### PR DESCRIPTION
This takes too long to build in qemu on a public runner. We can get a longer timeout (and probably more compute power) using the k8s runners