### PR TITLE
Fetch specific 1.72.1 version for rust

### DIFF
--- a/ubuntu-22.04-risc/Dockerfile
+++ b/ubuntu-22.04-risc/Dockerfile
@@ -16,4 +16,4 @@ RUN apt-get update && \
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BACKTRACE=1
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.1


### PR DESCRIPTION
Rust 1.73 seems to introduce some strange problem compiling modules needed for `chia_rs` - specifically `proc-macro2` 

fetch 1.72.1 instead - tested locally but unsure if it works with QEMU in CI