### PR TITLE
Switch to alternate latest tagging strategy for docker build workflows

### DIFF
--- a/.github/workflows/build-aptly.yml
+++ b/.github/workflows/build-aptly.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       docker-context: "./aptly"
       dockerfile: "./aptly/Dockerfile"
       dockerhub_imagename: "chianetwork/aptly"

--- a/.github/workflows/build-centos7.yml
+++ b/.github/workflows/build-centos7.yml
@@ -25,6 +25,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       docker-context: "./centos7"
       dockerfile: "./centos7/Dockerfile"
       dockerhub_imagename: "chianetwork/centos7-builder"

--- a/.github/workflows/build-db-webroot-backup.yml
+++ b/.github/workflows/build-db-webroot-backup.yml
@@ -24,6 +24,7 @@ jobs:
   package:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       docker-context: "./db-webroot-backup"
       dockerfile: "./db-webroot-backup/Dockerfile"
       image_subpath: "db-webroot-backup"

--- a/.github/workflows/build-phpfpm.yml
+++ b/.github/workflows/build-phpfpm.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       runs-on: "linux-arm64"
       docker-platforms: "linux/arm64"
       docker-context: "./phpfpm"

--- a/.github/workflows/build-rocky8.yml
+++ b/.github/workflows/build-rocky8.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       docker-context: "./rocky8"
       dockerfile: "./rocky8/Dockerfile"
       dockerhub_imagename: "chianetwork/rocky8-builder"

--- a/.github/workflows/build-ubuntu-18.04.yml
+++ b/.github/workflows/build-ubuntu-18.04.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       docker-context: "./ubuntu-18.04"
       dockerfile: "./ubuntu-18.04/Dockerfile"
       dockerhub_imagename: "chianetwork/ubuntu-18.04-builder"

--- a/.github/workflows/build-ubuntu-20.04.yml
+++ b/.github/workflows/build-ubuntu-20.04.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       docker-context: "./ubuntu-20.04"
       dockerfile: "./ubuntu-20.04/Dockerfile"
       dockerhub_imagename: "chianetwork/ubuntu-20.04-builder"

--- a/.github/workflows/build-ubuntu-22.04-risc.yml
+++ b/.github/workflows/build-ubuntu-22.04-risc.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       runs-on: k8s-public
       timeout-minutes: 1440
       docker-context: "./ubuntu-22.04-risc"

--- a/.github/workflows/build-ubuntu-22.04.yml
+++ b/.github/workflows/build-ubuntu-22.04.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      alternate-latest-mode: true
       docker-context: "./ubuntu-22.04"
       dockerfile: "./ubuntu-22.04/Dockerfile"
       dockerhub_imagename: "chianetwork/ubuntu-22.04-builder"

--- a/.github/workflows/build-wordpress.yml
+++ b/.github/workflows/build-wordpress.yml
@@ -37,6 +37,7 @@ jobs:
     needs:
       - get_version
     with:
+      alternate-latest-mode: true
       docker-context: "./wordpress"
       dockerfile: "./wordpress/Dockerfile"
       image_subpath: "wordpress"


### PR DESCRIPTION
The docker build job these workflows use don't tag latest by default anymore, this just overrides it back to tagging latest for main branch CI runs.