### PR TITLE
Add alpine container for musl wheel builds

### DIFF
--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -26,6 +26,7 @@ jobs:
     with:
       alternate-latest-mode: true
       docker-context: "./alpine"
+      docker-platforms: linux/amd64
       dockerfile: "./alpine/Dockerfile"
       dockerhub_imagename: "chianetwork/alpine-builder"
       image_subpath: "alpine-builder"

--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -1,0 +1,34 @@
+name: Build Alpine Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "alpine/*"
+      - ".github/workflows/build-alpine.yml"
+  pull_request:
+    paths:
+      - "alpine/*"
+      - ".github/workflows/build-alpine.yml"
+  workflow_dispatch:
+  schedule:
+    - cron: "30 12 * * 5"
+
+concurrency:
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
+    with:
+      alternate-latest-mode: true
+      docker-context: "./alpine"
+      dockerfile: "./alpine/Dockerfile"
+      dockerhub_imagename: "chianetwork/alpine-builder"
+      image_subpath: "alpine-builder"
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:3.16.2
+WORKDIR /root
+
+# Set environment variables for rust and pyenv
+ENV PYENV_ROOT=/root/.pyenv
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+ENV PATH="/root/.cargo/bin:${PATH}"
+ENV RUST_BACKTRACE=1
+
+RUN sh -c "echo https://mirrors.edge.kernel.org/alpine/v3.16.2/community >> /etc/apk/repositories"
+RUN apk add bash git curl python3 openssl openssl-dev perl linux-headers make gcc musl-dev patch patchelf
+# Additional pyenv dependencies
+RUN apk add --no-cache build-base libffi-dev bzip2-dev zlib-dev xz-dev readline-dev sqlite-dev tk-dev
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf -o rustup https://sh.rustup.rs
+RUN sh ./rustup -y
+
+# Build a copy of openssl - needed for the rust-openssl crate
+COPY build-openssl.sh .
+RUN sh ./build-openssl.sh
+
+RUN curl https://pyenv.run | bash && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.8 && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.9 && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.10 && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.11 && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.12

--- a/alpine/build-openssl.sh
+++ b/alpine/build-openssl.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm
 ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic
 ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux

--- a/alpine/build-openssl.sh
+++ b/alpine/build-openssl.sh
@@ -8,7 +8,7 @@ mkdir /musl
 
 wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1w.tar.gz
 tar zxvf OpenSSL_1_1_1w.tar.gz 
-cd openssl-OpenSSL_1_1_1w/
+cd openssl-OpenSSL_1_1_1w/ || exit
 
 CC="/usr/bin/x86_64-alpine-linux-musl-gcc -static" ./Configure no-shared no-async --prefix=/musl --openssldir=/musl/ssl linux-x86_64
 make depend

--- a/alpine/build-openssl.sh
+++ b/alpine/build-openssl.sh
@@ -12,5 +12,5 @@ cd openssl-OpenSSL_1_1_1w/ || exit
 
 CC="/usr/bin/x86_64-alpine-linux-musl-gcc -static" ./Configure no-shared no-async --prefix=/musl --openssldir=/musl/ssl linux-x86_64
 make depend
-make -j$(nproc)
+make -j"$(nproc)"
 make install

--- a/alpine/build-openssl.sh
+++ b/alpine/build-openssl.sh
@@ -1,0 +1,14 @@
+ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm
+ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic
+ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+
+mkdir /musl
+
+wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1w.tar.gz
+tar zxvf OpenSSL_1_1_1w.tar.gz 
+cd openssl-OpenSSL_1_1_1w/
+
+CC="/usr/bin/x86_64-alpine-linux-musl-gcc -static" ./Configure no-shared no-async --prefix=/musl --openssldir=/musl/ssl linux-x86_64
+make depend
+make -j$(nproc)
+make install


### PR DESCRIPTION
Add an alpine container we can use for building musl linux wheels

Currently the only place that builds these is `clvm_tools_rs` - but this is useful to have in case we want to support more musl linux wheels