### PR TITLE
use default rust for risc image

### DIFF
--- a/ubuntu-22.04-risc/Dockerfile
+++ b/ubuntu-22.04-risc/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BACKTRACE=1
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.1
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 FROM base as ld
 


### PR DESCRIPTION
### Draft For:
- [x] built on https://github.com/Chia-Network/build-images/pull/68