### PR TITLE
Fix wp versions parsing to match their version formatting

### DIFF
--- a/.github/workflows/build-wordpress.yml
+++ b/.github/workflows/build-wordpress.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get latest WP version
         id: wp-version
         run: |
-          WP_VERSION=$(curl -s https://latest.cmm.io/wordpress)
+          WP_VERSION=$(curl -s https://latest.cmm.io/wordpress | sed 's/\([0-9]*\.[0-9]*\)\.0$/\1/')
           echo "WP_VERSION=$WP_VERSION" >$GITHUB_OUTPUT
 
   build:


### PR DESCRIPTION
When they have a 6.5, 6.6, etc, they drop the trailing .0