### PR TITLE
set four hour timeout for risc build

### DIFF
--- a/.github/workflows/build-ubuntu-22.04-risc.yml
+++ b/.github/workflows/build-ubuntu-22.04-risc.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
+    timeout-minutes: 240
     with:
       alternate-latest-mode: true
       runs-on: k8s-public


### PR DESCRIPTION
It appears that successful runs take ballpark 1h 45m.  (pending caching effects maybe varying...)

![image](https://github.com/user-attachments/assets/d9fc6c4d-e434-4a0b-87d6-072d58c9fcb0)
