### PR TITLE
Revert "Update sqlite and ssl (#90)"

### DIFF
--- a/.github/workflows/build-ubuntu-22.04-risc.yml
+++ b/.github/workflows/build-ubuntu-22.04-risc.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      enable-qemu-cache: false
       alternate-latest-mode: true
       runs-on: k8s-public
       timeout-minutes: 240

--- a/.github/workflows/build-ubuntu-22.04-risc.yml
+++ b/.github/workflows/build-ubuntu-22.04-risc.yml
@@ -24,7 +24,6 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
-      enable-qemu-cache: false
       alternate-latest-mode: true
       runs-on: k8s-public
       timeout-minutes: 240

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.16.2
 WORKDIR /root
 
 # Set environment variables for rust and pyenv
@@ -7,7 +7,8 @@ ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BACKTRACE=1
 
-RUN apk add bash git curl python3 openssl openssl-dev perl linux-headers make gcc musl-dev patch patchelf py3-pip
+RUN sh -c "echo https://mirrors.edge.kernel.org/alpine/v3.16.2/community >> /etc/apk/repositories"
+RUN apk add bash git curl python3 openssl openssl-dev perl linux-headers make gcc musl-dev patch patchelf
 # Additional pyenv dependencies
 RUN apk add --no-cache build-base libffi-dev bzip2-dev zlib-dev xz-dev readline-dev sqlite-dev tk-dev
 
@@ -15,7 +16,12 @@ RUN apk add --no-cache build-base libffi-dev bzip2-dev zlib-dev xz-dev readline-
 RUN curl --proto '=https' --tlsv1.2 -sSf -o rustup https://sh.rustup.rs
 RUN sh ./rustup -y
 
+# Build a copy of openssl - needed for the rust-openssl crate
+COPY build-openssl.sh .
+RUN sh ./build-openssl.sh
+
 RUN curl https://pyenv.run | bash && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.8 && \
     PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.9 && \
     PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.10 && \
     PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install --skip-existing 3.11 && \

--- a/alpine/build-openssl.sh
+++ b/alpine/build-openssl.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm
+ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic
+ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+
+mkdir /musl
+
+wget https://github.com/openssl/openssl/archive/OpenSSL_1_1_1w.tar.gz
+tar zxvf OpenSSL_1_1_1w.tar.gz 
+cd openssl-OpenSSL_1_1_1w/ || exit
+
+CC="/usr/bin/x86_64-alpine-linux-musl-gcc -static" ./Configure no-shared no-async --prefix=/musl --openssldir=/musl/ssl linux-x86_64
+make depend
+make -j"$(nproc)"
+make install

--- a/rocky8/Dockerfile
+++ b/rocky8/Dockerfile
@@ -17,39 +17,25 @@ RUN yum -y groupinstall "Development Tools" && \
 
 # Compile newer version of sqlite3
 RUN cd ~ && \
-    wget -q https://www.sqlite.org/2024/sqlite-autoconf-3450100.tar.gz && \
-    tar -xzf sqlite-autoconf-3450100.tar.gz && \
-    cd sqlite-autoconf-3450100 && \
+    wget -q https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
+    tar -xzf sqlite-autoconf-3400100.tar.gz && \
+    cd sqlite-autoconf-3400100 && \
     CFLAGS="-DSQLITE_MAX_VARIABLE_NUMBER=500000" ./configure --prefix=/usr/sqlite3 && \
     make && \
     make install && \
     cd ~ && \
     rm -rf ~/sqlite-autoconf*
 
-# Compile newer version of openssl \
-RUN cd ~ && \
-yum -y install perl-IPC-Cmd perl-Pod-Html && \
-wget -q https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz && \
-tar -xzf openssl-3.0.15.tar.gz && \
-cd openssl-3.0.15 && \
-./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl --libdir=lib no-ssl3 no-idea no-dtls no-srp no-comp shared && \
-make && \
-make install && \
-cd ~ && \
-rm -rf ~/openssl-3.0.15*
-
 # Compile newer version of python3
-RUN yum -y install zlib-devel bzip2 bzip2-devel readline-devel tk-devel libffi-devel xz-devel && \
+RUN yum -y install openssl openssl-devel zlib-devel bzip2 bzip2-devel readline-devel tk-devel libffi-devel xz-devel && \
     cd ~ && \
     # Set up pyenv \
-    export PYTHON_CONFIGURE_OPTS="--with-openssl=/usr/local/ssl --with-openssl-rpath=auto --enable-shared --enable-optimizations" && \
     git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    pyenv install 3.11 --verbose && \
-    pyenv global 3.11 && \
+    pyenv install 3.10 && \
+    pyenv global 3.10 && \
     pip install --upgrade pip && \
     pip install --no-cache-dir py3createtorrent awscli && \
-    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")' && \
-    python3 -c 'import sys; import ssl; sys.exit(ssl.OPENSSL_VERSION_INFO != (3,0,0,15,0))' && \
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.40.1")' && \
     yum clean all
 
 # Add nodejs

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -42,42 +42,27 @@ RUN apt-get update && \
         vim \
         wget \
         xz-utils \
-        zlib1g-dev \
-        checkinstall && \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # Compile newer version of sqlite3 \
 RUN cd ~ && \
-    wget -q https://www.sqlite.org/2024/sqlite-autoconf-3450100.tar.gz && \
-    tar -xzf sqlite-autoconf-3450100.tar.gz && \
-    cd sqlite-autoconf-3450100 && \
+    wget -q https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
+    tar -xzf sqlite-autoconf-3400100.tar.gz && \
+    cd sqlite-autoconf-3400100 && \
     CFLAGS="-DSQLITE_MAX_VARIABLE_NUMBER=500000" ./configure --prefix=/usr && \
     make && \
     make install && \
     cd ~ && \
     rm -rf ~/sqlite-autoconf*
 
-# Compile newer version of openssl \
-RUN cd ~ && \
-wget -q https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz && \
-tar -xzf openssl-3.0.15.tar.gz && \
-cd openssl-3.0.15 && \
-./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl --libdir=lib no-ssl3 no-idea no-dtls no-srp no-comp shared && \
-make && \
-make install && \
-cd ~ && \
-rm -rf ~/openssl-3.0.15*
-
 # Set up pyenv \
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    export PYTHON_CONFIGURE_OPTS="--with-openssl=/usr/local/ssl --with-openssl-rpath=auto --enable-shared --enable-optimizations" && \
-    pyenv install 3.11 --verbose && \
-    pyenv global 3.11 && \
+    pyenv install 3.10 && \
+    pyenv global 3.10 && \
     pip install --upgrade pip && \
     pip install --no-cache-dir py3createtorrent && \
-    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")' && \
-    python3 -c 'import sys; import ssl; sys.exit(ssl.OPENSSL_VERSION_INFO != (3,0,0,15,0))'
-
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.40.1")'
 
 # Add nodejs
 ENV NODE_MAJOR=18

--- a/ubuntu-22.04-risc/Dockerfile
+++ b/ubuntu-22.04-risc/Dockerfile
@@ -18,9 +18,9 @@ RUN curl -L -O https://ftpmirror.gnu.org/gnu/binutils/binutils-2.38.tar.gz && \
 
 FROM base AS sqlite
 
-RUN curl -L -O https://sqlite.org/2024/sqlite-autoconf-3450100.tar.gz && \
-    tar -xvzf sqlite-autoconf-3450100.tar.gz && \
-    cd sqlite-autoconf-3450100 && \
+RUN curl -L -O https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
+    tar -xvzf sqlite-autoconf-3400100.tar.gz && \
+    cd sqlite-autoconf-3400100 && \
     CFLAGS="-DSQLITE_MAX_VARIABLE_NUMBER=500000" ./configure --prefix=/opt/sqlite3 && \
     make && \
     make install && \
@@ -55,6 +55,7 @@ RUN pyenv install 3.13
 RUN pyenv global 3.13 3.12 3.11 3.10 3.9
 
 # make sure sqlite is loaded from the expected path
+RUN ldd $(python3.8 -c 'import _sqlite3; print(_sqlite3.__file__)') | grep /opt/sqlite3/lib/
 RUN ldd $(python3.9 -c 'import _sqlite3; print(_sqlite3.__file__)') | grep /opt/sqlite3/lib/
 RUN ldd $(python3.10 -c 'import _sqlite3; print(_sqlite3.__file__)') | grep /opt/sqlite3/lib/
 RUN ldd $(python3.11 -c 'import _sqlite3; print(_sqlite3.__file__)') | grep /opt/sqlite3/lib/

--- a/ubuntu-22.04-risc/Dockerfile
+++ b/ubuntu-22.04-risc/Dockerfile
@@ -55,7 +55,6 @@ RUN pyenv install 3.13
 RUN pyenv global 3.13 3.12 3.11 3.10 3.9
 
 # make sure sqlite is loaded from the expected path
-RUN ldd $(python3.8 -c 'import _sqlite3; print(_sqlite3.__file__)') | grep /opt/sqlite3/lib/
 RUN ldd $(python3.9 -c 'import _sqlite3; print(_sqlite3.__file__)') | grep /opt/sqlite3/lib/
 RUN ldd $(python3.10 -c 'import _sqlite3; print(_sqlite3.__file__)') | grep /opt/sqlite3/lib/
 RUN ldd $(python3.11 -c 'import _sqlite3; print(_sqlite3.__file__)') | grep /opt/sqlite3/lib/

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -47,9 +47,9 @@ RUN apt-get update && \
 
 # Compile newer version of sqlite3 \
 RUN cd ~ && \
-    wget -q https://sqlite.org/2024/sqlite-autoconf-3450100.tar.gz && \
-    tar -xzf sqlite-autoconf-3450100.tar.gz && \
-    cd sqlite-autoconf-3450100 && \
+    wget -q https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
+    tar -xzf sqlite-autoconf-3400100.tar.gz && \
+    cd sqlite-autoconf-3400100 && \
     CFLAGS="-DSQLITE_MAX_VARIABLE_NUMBER=500000" ./configure --prefix=/usr && \
     make && \
     make install && \
@@ -58,12 +58,11 @@ RUN cd ~ && \
 
 # Set up pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    export PYTHON_CONFIGURE_OPTS="--enable-shared --enable-optimizations" && \
-    pyenv install 3.11 --verbose && \
-    pyenv global 3.11 && \
+    pyenv install 3.10 && \
+    pyenv global 3.10 && \
     pip install --upgrade pip && \
     pip install --no-cache-dir py3createtorrent && \
-    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")'
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.40.1")'
 
 # Add nodejs
 ENV NODE_MAJOR=18


### PR DESCRIPTION
This mostly reverts commit 5bfe33c5e3887743be0839300e117c01ce77ea48.

It does keep in the qemu cache option that was breaking riscv builds and removes 3.8 from the riscv image since that is EOL and quicker builds are nice