### PR TITLE
Add 3.11 to images with newer openssl as needed - also update sqlite

### DIFF
--- a/rocky8/Dockerfile
+++ b/rocky8/Dockerfile
@@ -17,25 +17,44 @@ RUN yum -y groupinstall "Development Tools" && \
 
 # Compile newer version of sqlite3
 RUN cd ~ && \
-    wget -q https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
-    tar -xzf sqlite-autoconf-3400100.tar.gz && \
-    cd sqlite-autoconf-3400100 && \
+    wget -q https://www.sqlite.org/2024/sqlite-autoconf-3450100.tar.gz && \
+    tar -xzf sqlite-autoconf-3450100.tar.gz && \
+    cd sqlite-autoconf-3450100 && \
     CFLAGS="-DSQLITE_MAX_VARIABLE_NUMBER=500000" ./configure --prefix=/usr/sqlite3 && \
     make && \
     make install && \
     cd ~ && \
     rm -rf ~/sqlite-autoconf*
 
+RUN cd ~ && \
+    yum -y install perl-IPC-Cmd perl-Pod-Html && \
+    wget -q https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz && \
+    tar -xzf openssl-3.0.15.tar.gz && \
+    cd openssl-3.0.15 && \
+    ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl --libdir=lib no-ssl3 no-idea no-dtls no-srp no-comp shared && \
+    make && \
+    make install && \
+    cd ~ && \
+    rm -rf ~/openssl-3.0.15*
+
 # Compile newer version of python3
 RUN yum -y install openssl openssl-devel zlib-devel bzip2 bzip2-devel readline-devel tk-devel libffi-devel xz-devel && \
     cd ~ && \
     # Set up pyenv \
     git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    pyenv install 3.10 && \
+    # setup python 3.10 \
+    PYTHON_CONFIGURE_OPTS="--enable-shared --enable-optimizations" pyenv install 3.10 && \
+    # setup python 3.11 w/ openssl 3 \
+    PYTHON_CONFIGURE_OPTS="--with-openssl=/usr/local/ssl --with-openssl-rpath=auto --enable-shared --enable-optimizations" pyenv install 3.11 && \
     pyenv global 3.10 && \
     pip install --upgrade pip && \
     pip install --no-cache-dir py3createtorrent awscli && \
-    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.40.1")' && \
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")' && \
+    pyenv global 3.11 && \
+    pip install --upgrade pip && \
+    pip install --no-cache-dir py3createtorrent awscli && \
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")' && \
+    python3 -c 'import sys; import ssl; sys.exit(ssl.OPENSSL_VERSION_INFO != (3,0,0,15,0))' && \
     yum clean all
 
 # Add nodejs

--- a/ubuntu-20.04/Dockerfile
+++ b/ubuntu-20.04/Dockerfile
@@ -47,22 +47,40 @@ RUN apt-get update && \
 
 # Compile newer version of sqlite3 \
 RUN cd ~ && \
-    wget -q https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
-    tar -xzf sqlite-autoconf-3400100.tar.gz && \
-    cd sqlite-autoconf-3400100 && \
+    wget -q https://www.sqlite.org/2024/sqlite-autoconf-3450100.tar.gz && \
+    tar -xzf sqlite-autoconf-3450100.tar.gz && \
+    cd sqlite-autoconf-3450100 && \
     CFLAGS="-DSQLITE_MAX_VARIABLE_NUMBER=500000" ./configure --prefix=/usr && \
     make && \
     make install && \
     cd ~ && \
     rm -rf ~/sqlite-autoconf*
 
+# Compile newer version of openssl \
+RUN cd ~ && \
+    wget -q https://github.com/openssl/openssl/releases/download/openssl-3.0.15/openssl-3.0.15.tar.gz && \
+    tar -xzf openssl-3.0.15.tar.gz && \
+    cd openssl-3.0.15 && \
+    ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl --libdir=lib no-ssl3 no-idea no-dtls no-srp no-comp shared && \
+    make && \
+    make install && \
+    cd ~ && \
+    rm -rf ~/openssl-3.0.15*
+
 # Set up pyenv \
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-    pyenv install 3.10 && \
+    PYTHON_CONFIGURE_OPTS="--enable-shared --enable-optimizations" pyenv install 3.10 && \
+    PYTHON_CONFIGURE_OPTS="--with-openssl=/usr/local/ssl --with-openssl-rpath=auto --enable-shared --enable-optimizations" pyenv install 3.11 && \
     pyenv global 3.10 && \
     pip install --upgrade pip && \
     pip install --no-cache-dir py3createtorrent && \
-    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.40.1")'
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")' && \
+    pyenv global 3.11 && \
+    pip install --upgrade pip && \
+    pip install --no-cache-dir py3createtorrent awscli && \
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")' && \
+    python3 -c 'import sys; import ssl; sys.exit(ssl.OPENSSL_VERSION_INFO != (3,0,0,15,0))' && \
+
 
 # Add nodejs
 ENV NODE_MAJOR=18

--- a/ubuntu-22.04-risc/Dockerfile
+++ b/ubuntu-22.04-risc/Dockerfile
@@ -18,9 +18,9 @@ RUN curl -L -O https://ftpmirror.gnu.org/gnu/binutils/binutils-2.38.tar.gz && \
 
 FROM base AS sqlite
 
-RUN curl -L -O https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
-    tar -xvzf sqlite-autoconf-3400100.tar.gz && \
-    cd sqlite-autoconf-3400100 && \
+RUN curl -L -O https://www.sqlite.org/2024/sqlite-autoconf-3450100.tar.gz && \
+    tar -xvzf sqlite-autoconf-3450100.tar.gz && \
+    cd sqlite-autoconf-3450100 && \
     CFLAGS="-DSQLITE_MAX_VARIABLE_NUMBER=500000" ./configure --prefix=/opt/sqlite3 && \
     make && \
     make install && \
@@ -42,7 +42,7 @@ ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
 RUN curl https://pyenv.run | bash
 
-ARG PYTHON_CONFIGURE_OPTS="--enable-shared"
+ARG PYTHON_CONFIGURE_OPTS="--enable-shared --enable-optimizations"
 ARG LDFLAGS="-Wl,-rpath,/opt/sqlite3/lib -L/opt/sqlite3/lib -lsqlite3"
 ARG CPPFLAGS="-I/opt/sqlite3/include"
 

--- a/ubuntu-22.04/Dockerfile
+++ b/ubuntu-22.04/Dockerfile
@@ -47,9 +47,9 @@ RUN apt-get update && \
 
 # Compile newer version of sqlite3 \
 RUN cd ~ && \
-    wget -q https://sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
-    tar -xzf sqlite-autoconf-3400100.tar.gz && \
-    cd sqlite-autoconf-3400100 && \
+    wget -q https://www.sqlite.org/2024/sqlite-autoconf-3450100.tar.gz && \
+    tar -xzf sqlite-autoconf-3450100.tar.gz && \
+    cd sqlite-autoconf-3450100 && \
     CFLAGS="-DSQLITE_MAX_VARIABLE_NUMBER=500000" ./configure --prefix=/usr && \
     make && \
     make install && \
@@ -58,11 +58,18 @@ RUN cd ~ && \
 
 # Set up pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
+    export PYTHON_CONFIGURE_OPTS="--enable-shared --enable-optimizations" && \
     pyenv install 3.10 && \
+    pyenv install 3.11 && \
     pyenv global 3.10 && \
     pip install --upgrade pip && \
     pip install --no-cache-dir py3createtorrent && \
-    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.40.1")'
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")' && \
+    pyenv global 3.11 && \
+    pip install --upgrade pip && \
+    pip install --no-cache-dir py3createtorrent && \
+    python3 -c 'import sys; import sqlite3; sys.exit(sqlite3.sqlite_version != "3.45.1")'
+
 
 # Add nodejs
 ENV NODE_MAJOR=18


### PR DESCRIPTION
Attempt to do this in a smarter way

Add python 3.11 rather than replace 3.10 so both should be available in the build image.
Update sqlite to 3.45.1 for both
Install openssl 3 on Ubuntu 20 and Rocky8 and use for python 3.11 only

This image should then be able to be used with either 3.10 or 3.11 (w/ updated openssl) as needed