### PR TITLE
run build-ubuntu-20.04.yml on `ubuntu-22.04`

### DIFF
--- a/.github/workflows/build-ubuntu-20.04.yml
+++ b/.github/workflows/build-ubuntu-20.04.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
+      runs-on: ubuntu-20.04
       alternate-latest-mode: true
       docker-context: "./ubuntu-20.04"
       dockerfile: "./ubuntu-20.04/Dockerfile"

--- a/.github/workflows/build-ubuntu-20.04.yml
+++ b/.github/workflows/build-ubuntu-20.04.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
     with:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       alternate-latest-mode: true
       docker-context: "./ubuntu-20.04"
       dockerfile: "./ubuntu-20.04/Dockerfile"


### PR DESCRIPTION
Recently creating the Ubuntu 20 images has been failing with strange errors. Current best guess is the runner switch to Ubuntu 24 caused some interaction with building the image (possibly qemu related with arm).

Switching the runner to specifically use Ubuntu 22 seems to have resolved this.

Additionally it would be much faster and simpler to build the ARM images on a native ARM runner.  https://github.com/Chia-Network/build-images/pull/99