### PR TITLE
Add chia-db-init container for bootstrapping full_node databases from S3

### DIFF
--- a/.github/workflows/build-chia-db-init.yml
+++ b/.github/workflows/build-chia-db-init.yml
@@ -1,0 +1,31 @@
+name: Build Chia DB Init Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'chia-db-init/*'
+      - '.github/workflows/build-chia-db-init.yml'
+  pull_request:
+    paths:
+      - 'chia-db-init/*'
+      - '.github/workflows/build-chia-db-init.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '30 12 * * 5'
+
+concurrency:
+  # SHA is added to the end if on `main` to let all main workflows run
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref == 'refs/heads/main' && github.sha || '' }}
+  cancel-in-progress: true
+
+jobs:
+  package:
+    uses: Chia-Network/actions/.github/workflows/docker-build.yaml@main
+    with:
+      alternate-latest-mode: true
+      docker-context: "./chia-db-init"
+      dockerfile: "./chia-db-init/Dockerfile"
+      image_subpath: "chia-db-init"
+      push: ${{ github.event_name != 'pull_request' }}

--- a/chia-db-init/Dockerfile
+++ b/chia-db-init/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+RUN apk add --no-cache aws-cli sqlite curl jq gzip
+
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/chia-db-init/Dockerfile
+++ b/chia-db-init/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --no-cache aws-cli sqlite curl jq gzip
+RUN apk add --no-cache aws-cli sqlite gzip
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/chia-db-init/entrypoint.sh
+++ b/chia-db-init/entrypoint.sh
@@ -27,10 +27,6 @@ get_local_height() {
     echo "$local_height"
 }
 
-check_cache_files() {
-    [ -f "${DB_DIR}/height-to-hash" ] && [ -f "${DB_DIR}/sub-epoch-summaries" ]
-}
-
 delete_db_files() {
     echo "Removing existing DB and cache files..."
     rm -f "$DB_PATH" "${DB_PATH}-shm" "${DB_PATH}-wal"
@@ -38,11 +34,11 @@ delete_db_files() {
     rm -f "${DB_DIR}/sub-epoch-summaries"
 }
 
-download_from_s3() {
+download_db_from_s3() {
     mkdir -p "$DB_DIR"
 
     echo "Downloading blockchain DB from S3..."
-    if aws s3 ls "${S3_PREFIX}/${DB_FILE}.gz" --region "$AWS_REGION" >/dev/null 2>&1; then
+    if aws s3api head-object --bucket "$S3_BUCKET" --key "${NETWORK}/${DB_FILE}.gz" --region "$AWS_REGION" >/dev/null 2>&1; then
         echo "Found gzipped DB, downloading ${DB_FILE}.gz..."
         aws s3 cp "${S3_PREFIX}/${DB_FILE}.gz" "${DB_PATH}.gz" --region "$AWS_REGION"
         echo "Decompressing ${DB_FILE}.gz..."
@@ -51,14 +47,20 @@ download_from_s3() {
         echo "No gzipped DB found, downloading uncompressed ${DB_FILE}..."
         aws s3 cp "${S3_PREFIX}/${DB_FILE}" "$DB_PATH" --region "$AWS_REGION"
     fi
+}
 
-    echo "Downloading height-to-hash..."
-    aws s3 cp "${S3_PREFIX}/height-to-hash" "${DB_DIR}/height-to-hash" --region "$AWS_REGION"
+download_cache_files() {
+    mkdir -p "$DB_DIR"
 
-    echo "Downloading sub-epoch-summaries..."
-    aws s3 cp "${S3_PREFIX}/sub-epoch-summaries" "${DB_DIR}/sub-epoch-summaries" --region "$AWS_REGION"
+    if [ ! -f "${DB_DIR}/height-to-hash" ]; then
+        echo "Downloading height-to-hash..."
+        aws s3 cp "${S3_PREFIX}/height-to-hash" "${DB_DIR}/height-to-hash" --region "$AWS_REGION"
+    fi
 
-    echo "S3 download complete"
+    if [ ! -f "${DB_DIR}/sub-epoch-summaries" ]; then
+        echo "Downloading sub-epoch-summaries..."
+        aws s3 cp "${S3_PREFIX}/sub-epoch-summaries" "${DB_DIR}/sub-epoch-summaries" --region "$AWS_REGION"
+    fi
 }
 
 echo "=== Chia DB Init ==="
@@ -76,21 +78,19 @@ if [ -f "$DB_PATH" ]; then
     local_height=$(get_local_height)
     echo "Local block height: ${local_height}"
 
-    if [ "$local_height" -ge "$MIN_HEIGHT" ] && check_cache_files; then
-        echo "Local DB has sufficient blocks (${local_height} >= ${MIN_HEIGHT}) and cache files present, no action needed"
+    if [ "$local_height" -ge "$MIN_HEIGHT" ]; then
+        echo "Local DB has sufficient blocks (${local_height} >= ${MIN_HEIGHT})"
+        download_cache_files
         echo "Done"
         exit 0
     fi
 
-    if [ "$local_height" -lt "$MIN_HEIGHT" ]; then
-        echo "Local height ${local_height} is below minimum ${MIN_HEIGHT}, re-downloading..."
-    else
-        echo "Cache files missing, re-downloading..."
-    fi
+    echo "Local height ${local_height} is below minimum ${MIN_HEIGHT}, re-downloading..."
     delete_db_files
 else
     echo "No existing DB found at ${DB_PATH}"
 fi
 
-download_from_s3
+download_db_from_s3
+download_cache_files
 echo "Done"

--- a/chia-db-init/entrypoint.sh
+++ b/chia-db-init/entrypoint.sh
@@ -16,8 +16,11 @@ DB_FILE="blockchain_v2_${NETWORK}.sqlite"
 DB_PATH="${DB_DIR}/${DB_FILE}"
 S3_PREFIX="s3://${S3_BUCKET}/${NETWORK}"
 
-HEIGHT_TO_HASH="${DB_DIR}/height-to-hash"
-SUB_EPOCH_SUMMARIES="${DB_DIR}/sub-epoch-summaries"
+if [ "$NETWORK" = "mainnet" ]; then
+    CACHE_SUFFIX=""
+else
+    CACHE_SUFFIX="-${NETWORK}"
+fi
 
 get_local_height() {
     local_height=$(sqlite3 "$DB_PATH" "SELECT MAX(height) FROM full_blocks;" 2>/dev/null || echo "")
@@ -33,8 +36,8 @@ get_local_height() {
 delete_db_files() {
     echo "Removing existing DB and cache files..."
     rm -f "$DB_PATH" "${DB_PATH}-shm" "${DB_PATH}-wal"
-    rm -f "$HEIGHT_TO_HASH"
-    rm -f "$SUB_EPOCH_SUMMARIES"
+    rm -f "${DB_DIR}/height-to-hash" "${DB_DIR}/height-to-hash${CACHE_SUFFIX}"
+    rm -f "${DB_DIR}/sub-epoch-summaries" "${DB_DIR}/sub-epoch-summaries${CACHE_SUFFIX}"
 }
 
 download_db_from_s3() {
@@ -52,18 +55,23 @@ download_db_from_s3() {
     fi
 }
 
+has_cache_file() {
+    # Check for both suffixed and unsuffixed variants
+    [ -f "${DB_DIR}/${1}${CACHE_SUFFIX}" ] || [ -f "${DB_DIR}/${1}" ]
+}
+
 download_cache_files() {
     mkdir -p "$DB_DIR"
 
-    if [ ! -f "$HEIGHT_TO_HASH" ]; then
-        echo "Downloading height-to-hash to ${HEIGHT_TO_HASH}..."
-        aws s3 cp "${S3_PREFIX}/height-to-hash" "$HEIGHT_TO_HASH" --region "$AWS_REGION" || \
+    if ! has_cache_file "height-to-hash"; then
+        echo "Downloading height-to-hash to ${DB_DIR}/height-to-hash${CACHE_SUFFIX}..."
+        aws s3 cp "${S3_PREFIX}/height-to-hash" "${DB_DIR}/height-to-hash${CACHE_SUFFIX}" --region "$AWS_REGION" || \
             echo "WARNING: Failed to download height-to-hash, node will regenerate it"
     fi
 
-    if [ ! -f "$SUB_EPOCH_SUMMARIES" ]; then
-        echo "Downloading sub-epoch-summaries to ${SUB_EPOCH_SUMMARIES}..."
-        aws s3 cp "${S3_PREFIX}/sub-epoch-summaries" "$SUB_EPOCH_SUMMARIES" --region "$AWS_REGION" || \
+    if ! has_cache_file "sub-epoch-summaries"; then
+        echo "Downloading sub-epoch-summaries to ${DB_DIR}/sub-epoch-summaries${CACHE_SUFFIX}..."
+        aws s3 cp "${S3_PREFIX}/sub-epoch-summaries" "${DB_DIR}/sub-epoch-summaries${CACHE_SUFFIX}" --region "$AWS_REGION" || \
             echo "WARNING: Failed to download sub-epoch-summaries, node will regenerate it"
     fi
 }

--- a/chia-db-init/entrypoint.sh
+++ b/chia-db-init/entrypoint.sh
@@ -16,6 +16,9 @@ DB_FILE="blockchain_v2_${NETWORK}.sqlite"
 DB_PATH="${DB_DIR}/${DB_FILE}"
 S3_PREFIX="s3://${S3_BUCKET}/${NETWORK}"
 
+HEIGHT_TO_HASH="${DB_DIR}/height-to-hash"
+SUB_EPOCH_SUMMARIES="${DB_DIR}/sub-epoch-summaries"
+
 get_local_height() {
     local_height=$(sqlite3 "$DB_PATH" "SELECT MAX(height) FROM full_blocks;" 2>/dev/null || echo "")
 
@@ -30,8 +33,8 @@ get_local_height() {
 delete_db_files() {
     echo "Removing existing DB and cache files..."
     rm -f "$DB_PATH" "${DB_PATH}-shm" "${DB_PATH}-wal"
-    rm -f "${DB_DIR}/height-to-hash"
-    rm -f "${DB_DIR}/sub-epoch-summaries"
+    rm -f "$HEIGHT_TO_HASH"
+    rm -f "$SUB_EPOCH_SUMMARIES"
 }
 
 download_db_from_s3() {
@@ -52,14 +55,16 @@ download_db_from_s3() {
 download_cache_files() {
     mkdir -p "$DB_DIR"
 
-    if [ ! -f "${DB_DIR}/height-to-hash" ]; then
-        echo "Downloading height-to-hash..."
-        aws s3 cp "${S3_PREFIX}/height-to-hash" "${DB_DIR}/height-to-hash" --region "$AWS_REGION"
+    if [ ! -f "$HEIGHT_TO_HASH" ]; then
+        echo "Downloading height-to-hash to ${HEIGHT_TO_HASH}..."
+        aws s3 cp "${S3_PREFIX}/height-to-hash" "$HEIGHT_TO_HASH" --region "$AWS_REGION" || \
+            echo "WARNING: Failed to download height-to-hash, node will regenerate it"
     fi
 
-    if [ ! -f "${DB_DIR}/sub-epoch-summaries" ]; then
-        echo "Downloading sub-epoch-summaries..."
-        aws s3 cp "${S3_PREFIX}/sub-epoch-summaries" "${DB_DIR}/sub-epoch-summaries" --region "$AWS_REGION"
+    if [ ! -f "$SUB_EPOCH_SUMMARIES" ]; then
+        echo "Downloading sub-epoch-summaries to ${SUB_EPOCH_SUMMARIES}..."
+        aws s3 cp "${S3_PREFIX}/sub-epoch-summaries" "$SUB_EPOCH_SUMMARIES" --region "$AWS_REGION" || \
+            echo "WARNING: Failed to download sub-epoch-summaries, node will regenerate it"
     fi
 }
 

--- a/chia-db-init/entrypoint.sh
+++ b/chia-db-init/entrypoint.sh
@@ -17,14 +17,18 @@ DB_PATH="${DB_DIR}/${DB_FILE}"
 S3_PREFIX="s3://${S3_BUCKET}/${NETWORK}"
 
 get_local_height() {
-    local_height=$(sqlite3 "$DB_PATH" "SELECT MAX(height) FROM full_blocks;" 2>/dev/null)
+    local_height=$(sqlite3 "$DB_PATH" "SELECT MAX(height) FROM full_blocks;" 2>/dev/null || echo "")
 
-    if [ -z "$local_height" ] || [ "$local_height" = "" ]; then
+    if [ -z "$local_height" ]; then
         echo "0"
         return
     fi
 
     echo "$local_height"
+}
+
+check_cache_files() {
+    [ -f "${DB_DIR}/height-to-hash" ] && [ -f "${DB_DIR}/sub-epoch-summaries" ]
 }
 
 delete_db_files() {
@@ -72,13 +76,17 @@ if [ -f "$DB_PATH" ]; then
     local_height=$(get_local_height)
     echo "Local block height: ${local_height}"
 
-    if [ "$local_height" -ge "$MIN_HEIGHT" ]; then
-        echo "Local DB has sufficient blocks (${local_height} >= ${MIN_HEIGHT}), no action needed"
+    if [ "$local_height" -ge "$MIN_HEIGHT" ] && check_cache_files; then
+        echo "Local DB has sufficient blocks (${local_height} >= ${MIN_HEIGHT}) and cache files present, no action needed"
         echo "Done"
         exit 0
     fi
 
-    echo "Local height ${local_height} is below minimum ${MIN_HEIGHT}, re-downloading..."
+    if [ "$local_height" -lt "$MIN_HEIGHT" ]; then
+        echo "Local height ${local_height} is below minimum ${MIN_HEIGHT}, re-downloading..."
+    else
+        echo "Cache files missing, re-downloading..."
+    fi
     delete_db_files
 else
     echo "No existing DB found at ${DB_PATH}"

--- a/chia-db-init/entrypoint.sh
+++ b/chia-db-init/entrypoint.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -e
+
+NETWORK="${NETWORK:-mainnet}"
+S3_BUCKET="${S3_BUCKET:-chia-blockchain-sqlite-backups}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+MIN_HEIGHT="${MIN_HEIGHT:-2000}"
+
+if [ -z "$CHIA_ROOT" ]; then
+    echo "ERROR: CHIA_ROOT is not set"
+    exit 1
+fi
+
+DB_DIR="${CHIA_ROOT}/db"
+DB_FILE="blockchain_v2_${NETWORK}.sqlite"
+DB_PATH="${DB_DIR}/${DB_FILE}"
+S3_PREFIX="s3://${S3_BUCKET}/${NETWORK}"
+
+get_local_height() {
+    local_height=$(sqlite3 "$DB_PATH" "SELECT MAX(height) FROM full_blocks;" 2>/dev/null)
+
+    if [ -z "$local_height" ] || [ "$local_height" = "" ]; then
+        echo "0"
+        return
+    fi
+
+    echo "$local_height"
+}
+
+delete_db_files() {
+    echo "Removing existing DB and cache files..."
+    rm -f "$DB_PATH" "${DB_PATH}-shm" "${DB_PATH}-wal"
+    rm -f "${DB_DIR}/height-to-hash"
+    rm -f "${DB_DIR}/sub-epoch-summaries"
+}
+
+download_from_s3() {
+    mkdir -p "$DB_DIR"
+
+    echo "Downloading blockchain DB from S3..."
+    if aws s3 ls "${S3_PREFIX}/${DB_FILE}.gz" --region "$AWS_REGION" >/dev/null 2>&1; then
+        echo "Found gzipped DB, downloading ${DB_FILE}.gz..."
+        aws s3 cp "${S3_PREFIX}/${DB_FILE}.gz" "${DB_PATH}.gz" --region "$AWS_REGION"
+        echo "Decompressing ${DB_FILE}.gz..."
+        gunzip -f "${DB_PATH}.gz"
+    else
+        echo "No gzipped DB found, downloading uncompressed ${DB_FILE}..."
+        aws s3 cp "${S3_PREFIX}/${DB_FILE}" "$DB_PATH" --region "$AWS_REGION"
+    fi
+
+    echo "Downloading height-to-hash..."
+    aws s3 cp "${S3_PREFIX}/height-to-hash" "${DB_DIR}/height-to-hash" --region "$AWS_REGION"
+
+    echo "Downloading sub-epoch-summaries..."
+    aws s3 cp "${S3_PREFIX}/sub-epoch-summaries" "${DB_DIR}/sub-epoch-summaries" --region "$AWS_REGION"
+
+    echo "S3 download complete"
+}
+
+echo "=== Chia DB Init ==="
+echo "Network:     ${NETWORK}"
+echo "CHIA_ROOT:   ${CHIA_ROOT}"
+echo "DB path:     ${DB_PATH}"
+echo "S3 bucket:   ${S3_BUCKET}"
+echo "AWS region:  ${AWS_REGION}"
+echo "Min height:  ${MIN_HEIGHT}"
+echo ""
+
+if [ -f "$DB_PATH" ]; then
+    echo "Found existing DB at ${DB_PATH}"
+
+    local_height=$(get_local_height)
+    echo "Local block height: ${local_height}"
+
+    if [ "$local_height" -ge "$MIN_HEIGHT" ]; then
+        echo "Local DB has sufficient blocks (${local_height} >= ${MIN_HEIGHT}), no action needed"
+        echo "Done"
+        exit 0
+    fi
+
+    echo "Local height ${local_height} is below minimum ${MIN_HEIGHT}, re-downloading..."
+    delete_db_files
+else
+    echo "No existing DB found at ${DB_PATH}"
+fi
+
+download_from_s3
+echo "Done"


### PR DESCRIPTION
## Summary

- Adds a new `chia-db-init` Docker image (Alpine-based) that acts as a Kubernetes init container for Chia full_node pods
- Checks `$CHIA_ROOT/db/` for an existing blockchain DB and pulls from S3 if missing or below a minimum block height (default 2000)
- Supports mainnet and testnet11, with configurable S3 bucket, region, and height threshold via environment variables
- Prefers gzipped DB downloads when available, also pulls `height-to-hash` and `sub-epoch-summaries` cache files
- Includes GitHub Actions workflow for automated image builds

## Environment Variables

| Variable | Default | Description |
|---|---|---|
| `CHIA_ROOT` | (required) | Path to chia data dir |
| `NETWORK` | `mainnet` | Network name: `mainnet` or `testnet11` |
| `S3_BUCKET` | `chia-blockchain-sqlite-backups` | S3 bucket name |
| `AWS_REGION` | `us-west-2` | AWS region for S3 |
| `MIN_HEIGHT` | `2000` | Minimum block height to consider DB valid |

## Test plan

- [ ] Build Docker image locally and verify it starts
- [ ] Test with existing DB (should detect height and skip download)
- [ ] Test without DB (should pull from S3)
- [ ] Verify gzipped download + decompression works for mainnet
- [ ] Verify uncompressed download works for testnet11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new container that downloads and deletes on-disk blockchain DB/cache files from S3; misconfiguration or S3 issues could cause repeated downloads or unexpected DB replacement during node startup.
> 
> **Overview**
> Adds a new `chia-db-init` Docker image intended for use as an init container to bootstrap `$CHIA_ROOT/db` from S3.
> 
> The `entrypoint.sh` checks an existing `blockchain_v2_${NETWORK}.sqlite` for minimum block height and either keeps it (while fetching missing cache files) or deletes and re-downloads the DB, preferring a gzipped object when available.
> 
> Adds a GitHub Actions workflow to build and publish the `chia-db-init` image on changes (and on a weekly schedule), using the shared `docker-build.yaml` workflow with concurrency controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00556449d6d86d3e4d384e6612fc4c481c6cafdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->